### PR TITLE
Etl-55 scripts workflow

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -1,6 +1,6 @@
 name: aws-deploy
 
-on: push
+on: [push, pull_request]
 
 jobs:
   pre-commit:
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.2
+      - uses: pre-commit/action@v2.0.3
 
   sceptre-deploy:
     name: Deploy CloudFormation templates using sceptre
@@ -57,7 +57,7 @@ jobs:
         run: |
           pipenv install --dev
 
-      - name: Assume AWS role in dev account
+      - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.CI_USER_ACCESS_KEY_ID }}

--- a/.github/workflows/upload-python.yaml
+++ b/.github/workflows/upload-python.yaml
@@ -1,0 +1,55 @@
+name: upload-python
+
+on:
+  push:
+    paths:
+      - '**.py'
+
+jobs:
+
+  upload:
+    name: Upload python scripts to bucket
+    runs-on: ubuntu-latest
+    environment: develop
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.CI_USER_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_USER_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
+          role-duration-seconds: 1200
+
+      - name: Set Ref
+        shell: python
+        run: |
+          import os
+          import sys
+
+          ref = os.environ['GITHUB_REF']
+          branch_prefix = 'refs/heads/'
+          tag_prefix = 'refs/tags/'
+          if(ref.startswith(branch_prefix)):
+            dir_path = ref[len(branch_prefix)] + '/'
+          elif(ref.startswith(tag_prefix)):
+            dir_path = ref[len(tag_prefix)] + '/'
+          else:
+            sys.exit(1)
+
+          os.environ['BUCKET_DIR_PATH'] = dir_path
+
+      - name: Copy python scripts to S3 bucket
+        env:
+          S3_BUCKET: sceptre-cloudformation-bucket-bucket-65ci2qog5w6l
+        run: |
+          aws s3 sync src/ s3://${{ env.S3_BUCKET }}/$BUCKET_DIR_PATH

--- a/src/glue/jobs/json_s3_to_parquet.py
+++ b/src/glue/jobs/json_s3_to_parquet.py
@@ -12,14 +12,15 @@
 # Before writing our tables to parquet datasets, we will add the recordId
 # measure (taskIdentifier), and year, month, day to each record in each table.
 
-import sys
-import os
 import boto3
-from pyspark import SparkContext
+import os
+import sys
+
 from awsglue import DynamicFrame
 from awsglue.context import GlueContext
-from awsglue.utils import getResolvedOptions
 from awsglue.job import Job
+from awsglue.utils import getResolvedOptions
+from pyspark import SparkContext
 
 glue_client = boto3.client("glue")
 args = getResolvedOptions(


### PR DESCRIPTION
This adds an additional workflow for the purpose of uploading python scripts to a bucket. This is necessary b/c the Glue jobs want to pull scripts from an S3 bucket.

This CICD workflow adds more complexity than I would like, but the current configuration of workflow scripts seems to be behaving itself for the moment.