### PR TITLE
Etl-55 scripts workflow part. 2

### DIFF
--- a/.github/workflows/upload-glue-scripts.yaml
+++ b/.github/workflows/upload-glue-scripts.yaml
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v2.0.3
+
       - name: Assume AWS role
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/upload-glue-scripts.yaml
+++ b/.github/workflows/upload-glue-scripts.yaml
@@ -30,26 +30,28 @@ jobs:
           role-to-assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
           role-duration-seconds: 1200
 
-      - name: Set Ref
+      - name: Set bucket directory path
         shell: python
         run: |
           import os
           import sys
 
           ref = os.environ['GITHUB_REF']
+          print(f'GITHUB_REF: {ref}')
           branch_prefix = 'refs/heads/'
           tag_prefix = 'refs/tags/'
           if(ref.startswith(branch_prefix)):
-            dir_path = ref[len(branch_prefix)] + '/'
+            dir_path = ref[len(branch_prefix):] + '/'
           elif(ref.startswith(tag_prefix)):
-            dir_path = ref[len(tag_prefix)] + '/'
+            dir_path = ref[len(tag_prefix):] + '/'
           else:
             sys.exit(1)
 
-          os.environ['BUCKET_DIR_PATH'] = dir_path
+          with open(os.environ['GITHUB_ENV'], 'w') as env_file:
+            env_file.write(f'BUCKET_DIR_PATH={dir_path}')
 
       - name: Copy python scripts to S3 bucket
         env:
           S3_BUCKET: sceptre-cloudformation-bucket-bucket-65ci2qog5w6l
         run: |
-          aws s3 sync src/ s3://${{ env.S3_BUCKET }}/$BUCKET_DIR_PATH
+          aws s3 sync src/glue/jobs/ s3://${{ env.S3_BUCKET }}/$BUCKET_DIR_PATH

--- a/.github/workflows/upload-glue-scripts.yaml
+++ b/.github/workflows/upload-glue-scripts.yaml
@@ -3,7 +3,7 @@ name: upload-python
 on:
   push:
     paths:
-      - '**.py'
+      - 'src/glue/jobs/*.py'
 
 jobs:
 


### PR DESCRIPTION
This is a refinement on the scripts workflow
1. Fixes an issue with the bucket directory setting
2. Alters the workflow to only trigger if path changes match pattern 'src/glue/jobs/*.py' rather than all py files. This will be necessary if we are going to keep the lambda in the same repository, or it will also trigger this workflow. It needs its own, separate workflow.