### PR TITLE
Etl-68/buckets

### DIFF
--- a/config/develop/glue-jobs.yaml
+++ b/config/develop/glue-jobs.yaml
@@ -2,8 +2,7 @@ template_path: glue-jobs.yaml
 stack_name: glue-jobs
 parameters:
   SourceBucketName: {{ stack_group_config.artifact_bucket_name }}
-  GlueDatabaseName: !stack_output_external glue-database::DatabaseName
   JobRole: !stack_output_external glue-job-role::RoleArn
-  S3OutputBucketName: !stack_output_external bridge-downstream-dev-output-bucket::BucketName
+  S3OutputBucketName: !stack_output_external bridge-downstream-dev-parquet-bucket::BucketName
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/develop/s3-intermediate-bucket.yaml
+++ b/config/develop/s3-intermediate-bucket.yaml
@@ -1,0 +1,8 @@
+template_path: s3-bucket.yaml
+stack_name: bridge-downstream-dev-intermediate-bucket
+parameters:
+  BucketName: bridge-downstream-dev-intermediate-data
+  ReadOnlyAccessArns:
+    - !stack_output_external glue-job-role::RoleArn
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/config/develop/s3-parquet-bucket.yaml
+++ b/config/develop/s3-parquet-bucket.yaml
@@ -1,7 +1,7 @@
 template_path: s3-bucket.yaml
-stack_name: bridge-downstream-dev-output-bucket
+stack_name: bridge-downstream-dev-parquet-bucket
 parameters:
-  BucketName: bridge-downstream-dev-output
+  BucketName: bridge-downstream-dev-parquet
   ReadWriteAccessArns:
     - !stack_output_external glue-job-role::RoleArn
 stack_tags:

--- a/config/develop/s3-source-bucket.yaml
+++ b/config/develop/s3-source-bucket.yaml
@@ -1,7 +1,7 @@
 template_path: s3-bucket.yaml
-stack_name: bridge-downstream-dev-input-bucket
+stack_name: bridge-downstream-dev-source-bucket
 parameters:
-  BucketName: bridge-downstream-dev-input
+  BucketName: bridge-downstream-dev-source
   ReadOnlyAccessArns:
     - !stack_output_external glue-job-role::RoleArn
 stack_tags:


### PR DESCRIPTION
Slight bucket refactor in preparation for workflow PR
Instead of just input/output buckets,
renamed input to source
renamed output to parquet
created a bucket called "intermediate" for the unpacked json and the job temp dir