### PR TITLE
ETL-68 Add workflows stack

### DIFF
--- a/config/develop/glue-workflows.yaml
+++ b/config/develop/glue-workflows.yaml
@@ -1,0 +1,10 @@
+template_path: glue-workflows.yaml
+stack_name: glue-workflows
+parameters:
+  SourceBucketName: !stack_output_external bridge-downstream-dev-source-bucket::BucketName
+  SourceKey: ''
+  JsonBucketName: !stack_output_external bridge-downstream-dev-intermediate-bucket::BucketName
+  ParquetBucketName: !stack_output_external bridge-downstream-dev-parquet-bucket::BucketName
+  GlueDatabaseName: !stack_output_external glue-database::DatabaseName
+stack_tags:
+  {{ stack_group_config.default_stack_tags }}

--- a/templates/glue-workflows.yaml
+++ b/templates/glue-workflows.yaml
@@ -1,0 +1,53 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: A set of Glue workflows for a study
+
+Parameters:
+
+  SourceBucketName:
+    Type: String
+
+  SourceKey:
+    Type: String
+
+  JsonBucketName:
+    Type: String
+
+  JsonPrefix:
+    Type: String
+    Default: raw_json
+
+  ParquetBucketName:
+    Type: String
+
+  ParquetPrefix:
+    Type: String
+    Default: parquet
+
+  GlueDatabaseName:
+    Type: String
+
+Resources:
+
+  S3ToJsonWorkflow:
+    Type: AWS::Glue::Workflow
+    Properties:
+      DefaultRunProperties:
+        source_bucket: !Ref SourceBucketName
+        source_key: !Ref SourceKey
+        json_bucket: !Ref JsonBucketName
+        json_prefix: !Ref JsonPrefix
+      Description: >-
+        Workflow that breaks apart an archive and stores individual files in S3
+      Name: S3ToJsonWorkflow
+
+  JsonToParquetWorkflow:
+    Type: AWS::Glue::Workflow
+    Properties:
+      DefaultRunProperties:
+        database: !Ref GlueDatabaseName
+        json_bucket: !Ref JsonBucketName
+        json_prefix: !Ref JsonPrefix
+        parquet_bucket: !Ref ParquetBucketName
+        parquet_prefix: !Ref ParquetPrefix
+      Description: Workflow for converting json to parquet
+      Name: JsonToParquetWorkflow


### PR DESCRIPTION
Add the workflows component of the pipeline.
The workflows and jobs will be joined up in the triggers stack.

depends on #13 
(note that this PR uses dpulls to indicate dependencies between PRs -- it is normal for this to fail on the dpulls check until the other is merged)