### PR TITLE
ETL-85: unique job names / stack decoupling

### DIFF
--- a/config/develop/glue-jobs.yaml
+++ b/config/develop/glue-jobs.yaml
@@ -8,5 +8,6 @@ parameters:
   JobRole: !stack_output_external glue-job-role::RoleArn
   S3OutputBucketName: !stack_output_external bridge-downstream-dev-parquet-bucket::BucketName
   BranchOrTagName: main
+  UniqueId: !rcmd git rev-parse HEAD
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/develop/study-example-1.yaml
+++ b/config/develop/study-example-1.yaml
@@ -1,5 +1,7 @@
 template_path: study-pipeline-infra.yaml
 stack_name: study-example-1
+dependencies:
+  - develop/glue-jobs.yaml
 parameters:
   StudyName: example-study-1
   TemplateBucketName: {{ stack_group_config.artifact_bucket_name }}
@@ -9,5 +11,15 @@ parameters:
   RoleArn: !stack_output_external glue-job-role::RoleArn
   ClassifierName: !stack_output_external array-of-records-classifier::ClassifierName
   SynapseAuthSsmParameterName: synapse-bridgedownstream-auth
+  S3ToJsonS3JobName: !stack_output_external glue-jobs::S3ToJsonS3JobName
+  AnswersParquetJobName: !stack_output_external glue-jobs::AnswersParquetJobName
+  InfoParquetJobName: !stack_output_external glue-jobs::InfoParquetJobName
+  MetadataParquetJobName: !stack_output_external glue-jobs::MetadataParquetJobName
+  MicrophoneLevelsParquetJobName: !stack_output_external glue-jobs::MicrophoneLevelsParquetJobName
+  MotionParquetJobName: !stack_output_external glue-jobs::MotionParquetJobName
+  TaskDataParquetJobName: !stack_output_external glue-jobs::TaskDataParquetJobName
+  TaskResultParquetJobName: !stack_output_external glue-jobs::TaskResultParquetJobName
+  WeatherParquetJobName  : !stack_output_external glue-jobs::WeatherParquetJobName
+
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/config/develop/study-example-2.yaml
+++ b/config/develop/study-example-2.yaml
@@ -1,5 +1,7 @@
 template_path: study-pipeline-infra.yaml
 stack_name: study-example-2
+dependencies:
+  - develop/glue-jobs.yaml
 parameters:
   StudyName: example-study-2
   TemplateBucketName: {{ stack_group_config.artifact_bucket_name }}
@@ -9,5 +11,14 @@ parameters:
   RoleArn: !stack_output_external glue-job-role::RoleArn
   ClassifierName: !stack_output_external array-of-records-classifier::ClassifierName
   SynapseAuthSsmParameterName: synapse-bridgedownstream-auth
+  S3ToJsonS3JobName: !stack_output_external glue-jobs::S3ToJsonS3JobName
+  AnswersParquetJobName: !stack_output_external glue-jobs::AnswersParquetJobName
+  InfoParquetJobName: !stack_output_external glue-jobs::InfoParquetJobName
+  MetadataParquetJobName: !stack_output_external glue-jobs::MetadataParquetJobName
+  MicrophoneLevelsParquetJobName: !stack_output_external glue-jobs::MicrophoneLevelsParquetJobName
+  MotionParquetJobName: !stack_output_external glue-jobs::MotionParquetJobName
+  TaskDataParquetJobName: !stack_output_external glue-jobs::TaskDataParquetJobName
+  TaskResultParquetJobName: !stack_output_external glue-jobs::TaskResultParquetJobName
+  WeatherParquetJobName  : !stack_output_external glue-jobs::WeatherParquetJobName
 stack_tags:
   {{ stack_group_config.default_stack_tags }}

--- a/templates/glue-jobs.yaml
+++ b/templates/glue-jobs.yaml
@@ -29,6 +29,11 @@ Parameters:
     Type: String
     Description: The S3 output bucket where temporary files will be written.
 
+  UniqueId:
+    Type: String
+    Description: A unique id for producing unique job names.
+    Default: ''
+
 Resources:
 
   TaskResultParquetJobStack:
@@ -41,6 +46,7 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   TaskDataParquetJobStack:
     Type: AWS::CloudFormation::Stack
@@ -52,6 +58,7 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   AnswersParquetJobStack:
     Type: AWS::CloudFormation::Stack
@@ -63,6 +70,7 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   InfoParquetJobStack:
     Type: AWS::CloudFormation::Stack
@@ -74,6 +82,7 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   MetadataParquetJobStack:
     Type: AWS::CloudFormation::Stack
@@ -85,6 +94,7 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   MicrophoneLevelsParquetJobStack:
     Type: AWS::CloudFormation::Stack
@@ -96,6 +106,7 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   MotionParquetJobStack:
     Type: AWS::CloudFormation::Stack
@@ -107,6 +118,7 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   WeatherParquetJobStack:
     Type: AWS::CloudFormation::Stack
@@ -118,17 +130,20 @@ Resources:
         JobRole: !Ref JobRole
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
+        UniqueId: !Ref UniqueId
 
   S3ToJsonS3JobStack:
     Type:  AWS::CloudFormation::Stack
     Properties:
       TemplateURL: !Sub https://${SourceBucketName}.s3.amazonaws.com/${CodeRepositoryName}/${BranchOrTagName}/templates/glue-python-job.yaml
       Parameters:
-        JobDescription: Convert data to JSONS3 data
+        JobDescription: Convert data to JSONS3 data - test
         JobRole: !Ref JobRole
-        MaxConcurrentRuns: 100
+        MaxConcurrentRuns: 150
         S3OutputBucketName: !Ref S3OutputBucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/s3_to_json_s3.py
+        UniqueId: !Ref UniqueId
+        PythonVersion: 3
 
 Outputs:
 

--- a/templates/glue-python-job.yaml
+++ b/templates/glue-python-job.yaml
@@ -12,14 +12,17 @@ Parameters:
     Type: String
     Description: The name or ARN of the IAM role that will run this job.
 
-  GlueVersion:
-    Type: String
-    Description: AWS Glue version determines the version of Python available
-    Default: '3.0' # Python 3.7
-
   S3ScriptLocation:
     Type: String
     Description: The S3 path to the script that the job runs.
+
+  PythonVersion:
+    Type: String
+    Description: Version of Python
+    AllowedValues:
+      - '2'
+      - '3'
+    Default: '3'
 
   MaxConcurrentRuns:
     Type: Number
@@ -51,6 +54,11 @@ Parameters:
     Description: Name of the Glue table
     Default: ''
 
+  UniqueId:
+    Type: String
+    Description: A unique id for producing unique job names
+    Default: ''
+
 Resources:
 
   PythonShellJob:
@@ -59,6 +67,7 @@ Resources:
       Command:
         Name: pythonshell
         ScriptLocation: !Ref S3ScriptLocation
+        PythonVersion: !Ref PythonVersion
       DefaultArguments:
         --TempDir: !Sub s3://${S3OutputBucketName}/tmp
         --enable-continuous-cloudwatch-log: !Ref ContinuousLog
@@ -66,9 +75,8 @@ Resources:
       Description: !Ref JobDescription
       ExecutionProperty:
         MaxConcurrentRuns: !Ref MaxConcurrentRuns
-      GlueVersion: !Ref GlueVersion
       MaxRetries: !Ref MaxRetries
-      Name: !Sub '${AWS::StackName}-Job'
+      Name: !Sub '${AWS::StackName}-Job-${UniqueId}'
       Role: !Ref JobRole
       Timeout: !Ref TimeoutInMinutes
 

--- a/templates/glue-spark-job.yaml
+++ b/templates/glue-spark-job.yaml
@@ -61,6 +61,11 @@ Parameters:
     Description: The job timeout in minutes (integer).
     Default: 120
 
+  UniqueId:
+    Type: String
+    Description: A unique id for producing unique job names
+    Default: ''
+
   WorkerType:
     Type: String
     Description: >-
@@ -116,7 +121,7 @@ Resources:
         MaxConcurrentRuns: !Ref MaxConcurrentRuns
       GlueVersion: !Ref GlueVersion
       MaxRetries: !Ref MaxRetries
-      Name: !Sub '${AWS::StackName}-Job'
+      Name: !Sub '${AWS::StackName}-Job-${UniqueId}'
       NumberOfWorkers: !Ref NumberOfWorkers
       Role: !Ref JobRole
       Timeout: !Ref TimeoutInMinutes

--- a/templates/study-pipeline-infra.yaml
+++ b/templates/study-pipeline-infra.yaml
@@ -54,6 +54,26 @@ Parameters:
       The name of an ssm parameter whose value is Synapse service account
       personal access token
 
+# Job Names
+  S3ToJsonS3JobName:
+    Type: String
+  AnswersParquetJobName:
+    Type: String
+  InfoParquetJobName:
+    Type: String
+  MetadataParquetJobName:
+    Type: String
+  MicrophoneLevelsParquetJobName:
+    Type: String
+  MotionParquetJobName:
+    Type: String
+  TaskDataParquetJobName:
+    Type: String
+  TaskResultParquetJobName:
+    Type: String
+  WeatherParquetJobName:
+    Type: String
+
 Resources:
 
   DatabaseStack:
@@ -93,27 +113,18 @@ Resources:
       Parameters:
         StudyName: !Ref StudyName
         S3ToJsonWorkflowName: !Sub ${WorkflowsStack.Outputs.S3ToJsonWorkflowName}
-        S3ToJsonS3JobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-S3ToJsonS3JobName
+        S3ToJsonS3JobName: !Ref S3ToJsonS3JobName
         JsonToParquetWorkflowName: !Sub ${WorkflowsStack.Outputs.JsonToParquetWorkflowName}
         StandardCrawlerName: !Sub ${CrawlersStack.Outputs.StandardCrawlerName}
         ArrayCrawlerName: !Sub ${CrawlersStack.Outputs.ArrayCrawlerName}
-        AnswersParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-AnswersParquetJobName
-        InfoParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-InfoParquetJobName
-        MetadataParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-MetadataParquetJobName
-        MicrophoneLevelsParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-MicrophoneLevelsParquetJobName
-        MotionParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-MotionParquetJobName
-        TaskDataParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-TaskDataParquetJobName
-        TaskResultParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-TaskResultParquetJobName
-        WeatherParquetJobName: !ImportValue
-          Fn::Sub: ${AWS::Region}-glue-jobs-WeatherParquetJobName
+        AnswersParquetJobName: !Ref AnswersParquetJobName
+        InfoParquetJobName: !Ref InfoParquetJobName
+        MetadataParquetJobName: !Ref MetadataParquetJobName
+        MicrophoneLevelsParquetJobName: !Ref MicrophoneLevelsParquetJobName
+        MotionParquetJobName: !Ref MotionParquetJobName
+        TaskDataParquetJobName: !Ref TaskDataParquetJobName
+        TaskResultParquetJobName: !Ref TaskResultParquetJobName
+        WeatherParquetJobName: !Ref WeatherParquetJobName
 
   LambdaStack:
     Type: AWS::CloudFormation::Stack


### PR DESCRIPTION
Introduce a uniquish value for job names so that replacement can happen without dependent stacks complaining. This may be overkill since I'm also decoupling the stacks by replacing CFN ImportValue with sceptre params.