### PR TITLE
ETL-99/spark UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+This document is a work in progress.
+
+*Things to cover: pipenv, Cloudformation, Sceptre, SAM, Github workflows, git hooks*
+
+### Monitoring
+
+Use a combination of Workflows and Glue Studio, both within the [Glue console](https://console.aws.amazon.com/glue/), for graphical monitoring. Workflows gives a good view of what's happening within a workflow, but for a better overview of all the job runs, Glue Studio is recommended. Either option will give you a link to the Cloudwatch logs for each job.
+
+#### Debugging Spark Issues
+If your job is failing due to Spark issues, the Spark UI may give additional useful information. All jobs are configured to output spark logs. The current solution for viewing the Spark History Server is to run it locally through Docker. In order to do this, you need to be able to authenticate with AWS and get temporary credentials, and to run a docker image. Follow these [directions](https://docs.aws.amazon.com/glue/latest/dg/monitor-spark-ui-history.html#monitor-spark-ui-history-local) provided by AWS to start the server.

--- a/config/develop/glue-jobs.yaml
+++ b/config/develop/glue-jobs.yaml
@@ -6,7 +6,7 @@ dependencies:
 parameters:
   SourceBucketName: {{ stack_group_config.artifact_bucket_name }}
   JobRole: !stack_output_external glue-job-role::RoleArn
-  S3OutputBucketName: !stack_output_external bridge-downstream-dev-parquet-bucket::BucketName
+  S3BucketName: !stack_output_external bridge-downstream-dev-intermediate-bucket::BucketName
   BranchOrTagName: main
   UniqueId: !rcmd git rev-parse HEAD
 stack_tags:

--- a/config/develop/study-example-1.yaml
+++ b/config/develop/study-example-1.yaml
@@ -4,6 +4,7 @@ dependencies:
   - develop/glue-jobs.yaml
 parameters:
   StudyName: example-study-1
+  BranchOrTagName: main
   TemplateBucketName: {{ stack_group_config.artifact_bucket_name }}
   SourceBucketName: !stack_output_external bridge-downstream-dev-source-bucket::BucketName
   JsonBucketName: !stack_output_external bridge-downstream-dev-intermediate-bucket::BucketName

--- a/config/develop/study-example-2.yaml
+++ b/config/develop/study-example-2.yaml
@@ -4,6 +4,7 @@ dependencies:
   - develop/glue-jobs.yaml
 parameters:
   StudyName: example-study-2
+  BranchOrTagName: main
   TemplateBucketName: {{ stack_group_config.artifact_bucket_name }}
   SourceBucketName: !stack_output_external bridge-downstream-dev-source-bucket::BucketName
   JsonBucketName: !stack_output_external bridge-downstream-dev-intermediate-bucket::BucketName

--- a/templates/glue-jobs.yaml
+++ b/templates/glue-jobs.yaml
@@ -25,9 +25,9 @@ Parameters:
     Type: String
     Description: The name or ARN of the IAM role that will run this job.
 
-  S3OutputBucketName:
+  S3BucketName:
     Type: String
-    Description: The S3 output bucket where temporary files will be written.
+    Description: The name of the S3 bucket where temporary files and logs are written.
 
   UniqueId:
     Type: String
@@ -44,7 +44,7 @@ Resources:
         JobDescription: Export taskresult data in parquet format
         GlueTableName: dataset_taskresult
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -56,7 +56,7 @@ Resources:
         JobDescription: Export taskdata data in parquet format
         GlueTableName: dataset_taskdata
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -68,7 +68,7 @@ Resources:
         JobDescription: Export answers data in parquet format
         GlueTableName: dataset_answers
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -80,7 +80,7 @@ Resources:
         JobDescription: Export info data in parquet format
         GlueTableName: dataset_info
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -92,7 +92,7 @@ Resources:
         JobDescription: Export metadata data in parquet format
         GlueTableName: dataset_metadata
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -104,7 +104,7 @@ Resources:
         JobDescription: Export microphone levels data in parquet format
         GlueTableName: dataset_microphone_levels
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -116,7 +116,7 @@ Resources:
         JobDescription: Export motion data in parquet format
         GlueTableName: dataset_motion
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -128,7 +128,7 @@ Resources:
         JobDescription: Export weather data in parquet format
         GlueTableName: dataset_weather
         JobRole: !Ref JobRole
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/json_s3_to_parquet.py
         UniqueId: !Ref UniqueId
 
@@ -140,7 +140,7 @@ Resources:
         JobDescription: Convert data to JSONS3 data - test
         JobRole: !Ref JobRole
         MaxConcurrentRuns: 150
-        S3OutputBucketName: !Ref S3OutputBucketName
+        S3BucketName: !Ref S3BucketName
         S3ScriptLocation: !Sub s3://${SourceBucketName}/${CodeRepositoryName}/${BranchOrTagName}/glue/jobs/s3_to_json_s3.py
         UniqueId: !Ref UniqueId
         PythonVersion: 3

--- a/templates/glue-python-job.yaml
+++ b/templates/glue-python-job.yaml
@@ -45,7 +45,7 @@ Parameters:
     Default: 'true'
     AllowedValues: ['true', 'false']
 
-  S3OutputBucketName:
+  S3BucketName:
     Type: String
     Description: The name of the S3 bucket where temporary files are written.
 
@@ -69,8 +69,9 @@ Resources:
         ScriptLocation: !Ref S3ScriptLocation
         PythonVersion: !Ref PythonVersion
       DefaultArguments:
-        --TempDir: !Sub s3://${S3OutputBucketName}/tmp
+        --TempDir: !Sub s3://${S3BucketName}/tmp
         --enable-continuous-cloudwatch-log: !Ref ContinuousLog
+        --enable-metrics: true
         --table: !Ref GlueTableName
       Description: !Ref JobDescription
       ExecutionProperty:

--- a/templates/glue-spark-job.yaml
+++ b/templates/glue-spark-job.yaml
@@ -93,9 +93,9 @@ Parameters:
     Default: 'true'
     AllowedValues: ['true', 'false']
 
-  S3OutputBucketName:
+  S3BucketName:
     Type: String
-    Description: The name of the S3 bucket where temporary files are written.
+    Description: The name of the S3 bucket where temporary files and logs are written.
 
   GlueTableName:
     Type: String
@@ -111,11 +111,15 @@ Resources:
         Name: !Ref JobCommand
         ScriptLocation: !Ref S3ScriptLocation
       DefaultArguments:
-        --TempDir: !Sub s3://${S3OutputBucketName}/tmp
+        --TempDir: !Sub s3://${S3BucketName}/tmp
         --enable-continuous-cloudwatch-log: !Ref ContinuousLog
+        --enable-metrics: true
+        --enable-spark-ui: true
+        --spark-event-logs-path: !Sub s3://${S3BucketName}/spark-logs/${AWS::StackName}/
         --job-bookmark-option: !Ref BookmarkOption
         --job-language: !Ref JobLanguage
         --table: !Ref GlueTableName
+        # --conf spark.sql.adaptive.enabled
       Description: !Ref JobDescription
       ExecutionProperty:
         MaxConcurrentRuns: !Ref MaxConcurrentRuns


### PR DESCRIPTION
This enables the Spark UI for Spark jobs -- the config options is a bit misnamed. Actually it just saves the spark logs so you can ingest them into Spark History Server. I also added CONTRIBUTING.md to explain how to spin up a docker container for that.