### PR TITLE
Use github action expression instead of bash environment variable

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -18,7 +18,7 @@ jobs:
           role_to_assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
 
       - name: Remove sceptre stacks
-        run: pipenv run sceptre --var "namespace=$GITHUB_REF_NAME" delete develop/namespaced --yes
+        run: pipenv run sceptre --debug --var "namespace=${{ github.ref_name }}" delete develop/namespaced --yes
 
       - name: Remove artifacts
-        run: pipenv run python src/scripts/manage_artifacts/artifacts.py --remove --namespace "$GITHUB_REF_NAME"
+        run: pipenv run python src/scripts/manage_artifacts/artifacts.py --remove --namespace "${{ github.ref_name }}"


### PR DESCRIPTION
Changes syntax in cleanup.yaml to use github expression instead of an environment variable in an effort to fix bug when deleting sceptre stacks.