### PR TITLE
Use the correct ref name from the delete event when cleaning up

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -18,7 +18,7 @@ jobs:
           role_to_assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
 
       - name: Remove sceptre stacks
-        run: pipenv run sceptre --debug --var "namespace=${{ github.ref_name }}" delete develop/namespaced --yes
+        run: pipenv run sceptre --debug --var "namespace=${{ github.event.ref }}" delete develop/namespaced --yes
 
       - name: Remove artifacts
-        run: pipenv run python src/scripts/manage_artifacts/artifacts.py --remove --namespace "${{ github.ref_name }}"
+        run: pipenv run python src/scripts/manage_artifacts/artifacts.py --remove --namespace "${{ github.event.ref }}"


### PR DESCRIPTION
The problem with the cleanup.yaml has been that the `ref_name` field of the DELETE event's payload is _not_ the name of the branch being deleted -- it is `main`. To get the name of the branch being deleted, use `event.ref`.