### PR TITLE
[ETL-117] Lambda polls from SQS queue

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -62,7 +62,7 @@ jobs:
             --no-progressbar
 
           aws s3 cp .aws-sam/build/template.yaml \
-            s3://$CFN_BUCKET/$REPO_NAME/$GITHUB_REF_NAME/templates/lambda/sns_to_glue/
+            s3://$CFN_BUCKET/$REPO_NAME/$NAMESPACE/templates/lambda/sns_to_glue/
 
   sceptre-deploy-branch:
     name: Deploy branch using sceptre

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,6 @@
 project_code: bridge_downstream
 namespace: {{ var.namespace | default('bridge-downstream') }}
+latest_version: v0.1
 region: us-east-1
 artifact_bucket_name: sceptre-cloudformation-bucket-bucket-65ci2qog5w6l
 synapseAuthSsmParameterName: synapse-bridgedownstream-auth
@@ -9,6 +10,6 @@ default_stack_tags:
   Project: mobile-toolbox
   OwnerEmail: aws-mobilehealth-dataengineering-dev@sagebase.org
 j2_environment:
-   extensions:
-      - jinja2.ext.do
-      - jinja2.ext.debug
+  extensions:
+    - jinja2.ext.do
+    - jinja2.ext.debug

--- a/config/develop/namespaced/example-app-1-study-1.yaml
+++ b/config/develop/namespaced/example-app-1-study-1.yaml
@@ -12,7 +12,7 @@ parameters:
   AppName: example-app-1
   StudyName: study-1
   TemplateBucketName: {{ stack_group_config.artifact_bucket_name }}
-  ArtifactRef: v0.1
+  ArtifactRef: {{ stack_group_config.latest_version }}
   SourceBucketName: !stack_output_external bridge-downstream-dev-source-bucket::BucketName
   JsonBucketName: !stack_output_external bridge-downstream-dev-intermediate-bucket::BucketName
   ParquetBucketName: !stack_output_external bridge-downstream-dev-parquet-bucket::BucketName

--- a/config/develop/namespaced/glue-job-S3ToJsonS3.yaml
+++ b/config/develop/namespaced/glue-job-S3ToJsonS3.yaml
@@ -1,5 +1,4 @@
 #{% set ns = stack_group_config.namespace %}
-#{% set glue_script_tag = 'v0.1' %}
 template_path: glue-spark-job.j2
 dependencies:
   - develop/s3-intermediate-bucket.yaml
@@ -10,7 +9,7 @@ parameters:
   BookmarkOption: job-bookmark-disable
   JobDescription: Convert data to JSONS3 data
   MaxConcurrentRuns: '150'
-  S3ScriptLocation: s3://{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ glue_script_tag }}/glue/jobs/s3_to_json_s3.py
+  S3ScriptLocation: s3://{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.latest_version }}/glue/jobs/s3_to_json_s3.py
   SynapseAuthSsmParameterName: {{ stack_group_config.synapseAuthSsmParameterName }}
   AdditionalPythonModules: 'synapseclient'
   DatasetMapping: s3://{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.namespace }}/glue/resources/dataset_mapping.json

--- a/config/develop/namespaced/sqs-to-glue-lambda.yaml
+++ b/config/develop/namespaced/sqs-to-glue-lambda.yaml
@@ -1,7 +1,7 @@
 template:
   type: s3
   path: '{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.namespace }}/templates/lambda/sns_to_glue/template.yaml'
-stack_name: sqs-to-glue-lambda
+stack_name: '{{ stack_group_config.namespace }}-lambda-SQSToGlue'
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   Namespace: {{ stack_group_config.namespace }}

--- a/config/develop/sqs-to-glue-lambda.yaml
+++ b/config/develop/sqs-to-glue-lambda.yaml
@@ -1,7 +1,8 @@
 template:
   type: s3
   path: '{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.namespace }}/templates/lambda/sns_to_glue/template.yaml'
-stack_name: lambda
+stack_name: sqs-to-glue-lambda
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:
   Namespace: {{ stack_group_config.namespace }}
+  SQSQueueArn: !stack_output_external '{{ stack_group_config.namespace }}-sqs-SNSToLambda::PrimaryQueueArn'

--- a/config/develop/sqs-to-glue-lambda.yaml
+++ b/config/develop/sqs-to-glue-lambda.yaml
@@ -1,6 +1,6 @@
 template:
   type: s3
-  path: '{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.latest_version }}/templates/lambda/sns_to_glue/template.yaml'
+  path: '{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.namespace }}/templates/lambda/sns_to_glue/template.yaml'
 stack_name: lambda
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:

--- a/config/develop/sqs-to-glue-lambda.yaml
+++ b/config/develop/sqs-to-glue-lambda.yaml
@@ -1,0 +1,7 @@
+template:
+  type: s3
+  path: '{{ artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.latest_version }}/templates/lambda/sns_to_glue/template.yaml'
+stack_name: lambda
+stack_tags: {{ stack_group_config.default_stack_tags }}
+parameters:
+  Namespace: {{ stack_group_config.namespace }}

--- a/config/develop/sqs-to-glue-lambda.yaml
+++ b/config/develop/sqs-to-glue-lambda.yaml
@@ -1,6 +1,6 @@
 template:
   type: s3
-  path: '{{ artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.latest_version }}/templates/lambda/sns_to_glue/template.yaml'
+  path: '{{ stack_group_config.artifact_bucket_name }}/BridgeDownstream/{{ stack_group_config.latest_version }}/templates/lambda/sns_to_glue/template.yaml'
 stack_name: lambda
 stack_tags: {{ stack_group_config.default_stack_tags }}
 parameters:

--- a/src/lambda/template.yaml
+++ b/src/lambda/template.yaml
@@ -66,7 +66,7 @@ Resources:
             BatchSize: 20
             MaximumBatchingWindowInSeconds: 20
             Queue: !Ref SQSQueueArn
-      Timeout: 600
+      Timeout: 30
       Environment:
         Variables:
           NAMESPACE: !Ref Namespace

--- a/src/lambda/template.yaml
+++ b/src/lambda/template.yaml
@@ -13,9 +13,13 @@ Parameters:
     Type: String
     Description: Namespace of the stack so that it may be unique
 
+  SQSQueueArn:
+    Type: String
+    Description: ARN of SQS queue to poll for messages
+
 Resources:
 
-  SnsToGlueRole:
+  SqsToGlueRole:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -39,16 +43,12 @@ Resources:
             Resource:
             - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:workflow/*
 
-  SnsToGlueFunction:
+  SqsToGlueFunction:
     Type: AWS::Serverless::Function
     Properties:
       PackageType: Image
-      Role: !GetAtt SnsToGlueRole.Arn
-      Events:
-        SnsToGlue:
-          Type: SNS
-          Properties:
-            Topic: !Ref SnsTopic
+      Role: !GetAtt SqsToGlueRole.Arn
+      Events: !Ref SqsEventSource
       Timeout: 600
       Environment:
         Variables:
@@ -58,20 +58,18 @@ Resources:
       DockerContext: ./sns_to_glue
       DockerTag: v0.1
 
-  SnsTopic:
-    Type: AWS::SNS::Topic
-
-  SnsSubscription:
-    Type: AWS::SNS::Subscription
+  SqsEventSource:
+    Type: AWS::Lambda::EventSourceMapping
     Properties:
-      Protocol: lambda
-      TopicArn: !Ref SnsTopic
-      Endpoint: !GetAtt SnsToGlueFunction.Arn
+      BatchSize: 20
+      EventSourceArn: !Ref SQSQueueArn
+      FunctionName: !GetAtt SqsToGlueFunction.Arn
+      MaximumBatchingWindowInSeconds: 20
 
   LambdaInvocationPermission:
     Type: AWS::Lambda::Permission
     Properties:
-      FunctionName: !GetAtt SnsToGlueFunction.Arn
+      FunctionName: !GetAtt SqsToGlueFunction.Arn
       Action: lambda:InvokeFunction
-      SourceArn: !Ref SnsTopic
-      Principal: sns.amazonaws.com
+      SourceArn: !Ref SQSQueueArn
+      Principal: sqs.amazonaws.com

--- a/src/lambda/template.yaml
+++ b/src/lambda/template.yaml
@@ -48,7 +48,13 @@ Resources:
     Properties:
       PackageType: Image
       Role: !GetAtt SqsToGlueRole.Arn
-      Events: !Ref SqsEventSource
+      Events:
+        SQSEvent:
+          Type: SQS
+          Properties:
+            BatchSize: 20
+            MaximumBatchingWindowInSeconds: 20
+            Queue: !Ref SQSQueueArn
       Timeout: 600
       Environment:
         Variables:
@@ -57,14 +63,6 @@ Resources:
       Dockerfile: Dockerfile
       DockerContext: ./sns_to_glue
       DockerTag: v0.1
-
-  SqsEventSource:
-    Type: AWS::Lambda::EventSourceMapping
-    Properties:
-      BatchSize: 20
-      EventSourceArn: !Ref SQSQueueArn
-      FunctionName: !GetAtt SqsToGlueFunction.Arn
-      MaximumBatchingWindowInSeconds: 20
 
   LambdaInvocationPermission:
     Type: AWS::Lambda::Permission

--- a/src/lambda/template.yaml
+++ b/src/lambda/template.yaml
@@ -42,6 +42,17 @@ Resources:
             - glue:PutWorkflowRunProperties
             Resource:
             - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:workflow/*
+      - PolicyName: PollSQSQueue
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+          - Effect: Allow
+            Action:
+            - sqs:DeleteMessage
+            - sqs:GetQueueAttributes
+            - sqs:ReceiveMessage
+            Resource:
+            - !Ref SQSQueueArn
 
   SqsToGlueFunction:
     Type: AWS::Serverless::Function

--- a/src/lambda/template.yaml
+++ b/src/lambda/template.yaml
@@ -2,16 +2,12 @@ AWSTemplateFormatVersion: '2010-09-09'
 
 Transform: AWS::Serverless-2016-10-31
 
-Description:  >
+Description: >
   python3.8
 
   SAM Template for sns-to-glue
 
 Parameters:
-
-  WorkflowName:
-    Type: String
-    Description: Name of the glue workflow to start when new data arrives
 
   Namespace:
     Type: String
@@ -41,7 +37,7 @@ Resources:
             - glue:StartWorkflowRun
             - glue:PutWorkflowRunProperties
             Resource:
-            - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:workflow/${WorkflowName}
+            - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:workflow/*
 
   SnsToGlueFunction:
     Type: AWS::Serverless::Function

--- a/src/lambda/test-env-vars.json
+++ b/src/lambda/test-env-vars.json
@@ -1,7 +1,5 @@
 {
-  "SnsToGlueFunction": {
-    "SSM_PARAMETER_NAME": "synapse-bridgedownstream-auth",
-    "GLUE_WORKFLOW_NAME": "example-app-1-study-1-S3ToJsonWorkflow",
+  "SqsToGlueFunction": {
     "NAMESPACE": "bridge-downstream"
   }
 }

--- a/templates/sqs-queue.yaml
+++ b/templates/sqs-queue.yaml
@@ -30,18 +30,17 @@ Resources:
             AWS: !Sub '${AWS::AccountId}'
           Action:
           - SQS:*
-          Resource: !Ref PrimaryQueue
-        - Sid: SNS
+          Resource: !GetAtt PrimaryQueue.Arn
+        - Sid: SNSSend
           Effect: Allow
           Principal:
             AWS: '*'
           Action:
           - SQS:SendMessage
-          Resource: !Ref PrimaryQueue
+          Resource: !GetAtt PrimaryQueue.Arn
           Condition:
-            ArnEquals:
-              'aws:SourceArn': !Ref SnsTopic
-
+            ArnLike:
+              "aws:SourceArn": !Ref SnsTopic
       Queues:
       - !Ref PrimaryQueue
 
@@ -68,7 +67,7 @@ Resources:
             AWS: !Sub '${AWS::AccountId}'
           Action:
           - SQS:*
-          Resource: !Ref DeadLetterQueue
+          Resource: !GetAtt DeadLetterQueue.Arn
       Queues:
       - !Ref DeadLetterQueue
 

--- a/templates/sqs-queue.yaml
+++ b/templates/sqs-queue.yaml
@@ -81,3 +81,10 @@ Resources:
       Protocol: sqs
       TopicArn: !Ref SnsTopic
       Endpoint: !GetAtt PrimaryQueue.Arn
+
+Outputs:
+
+  PrimaryQueueArn:
+    Value: !GetAtt PrimaryQueue.Arn
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-PrimaryQueueArn'

--- a/templates/study-pipeline-infra.j2
+++ b/templates/study-pipeline-infra.j2
@@ -279,11 +279,3 @@ Resources:
       StartOnCreation: true
       Type: CONDITIONAL
       WorkflowName: !Ref JsonToParquetWorkflow
-
-  LambdaStack:
-    Type: AWS::CloudFormation::Stack
-    Properties:
-      TemplateURL: !Sub https://${TemplateBucketName}.s3.amazonaws.com/${CodeRepositoryName}/${ArtifactRef}/templates/lambda/sns_to_glue/template.yaml
-      Parameters:
-        WorkflowName: !Ref S3ToJsonWorkflow
-        Namespace: !Ref Namespace


### PR DESCRIPTION
* Lambda has been pulled out of the study stack and is now in its own stack
* "sns to glue" nomenclature has been changed to "sqs to glue"
* Both Lambda and SQS queue are namespaced
* Lambda has permissions to invoke any glue workflow, not just one associated with a specific study or namespace
* The commit which used to be in this branch which changed the test events from SQS events to SNS events has been omitted (i.e., they're SQS events again). I'm not sure why I thought we would be passing those test events to the SQS queue rather than our lambda...