### PR TITLE
Revert changes to config synapseBridgeDownstreamUserId parameter

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -3,7 +3,6 @@ namespace: {{ var.namespace | default('bridge-downstream') }}
 latest_version: v0.1
 region: us-east-1
 synapseAuthSsmParameterName: synapse-bridgedownstream-auth
-synapseBridgeDownstreamUserId: 3432808
 admincentral_cf_bucket: bootstrap-awss3cloudformationbucket-19qromfd235z9
 default_stack_tags:
   Department: IBC

--- a/config/prod/s3-parquet-bucket.yaml
+++ b/config/prod/s3-parquet-bucket.yaml
@@ -2,6 +2,6 @@ template_path: s3-bucket.yaml
 stack_name: bridge-downstream-parquet-bucket
 parameters:
   BucketName: bridge-downstream-parquet
-  SynapseIds: {{ stack_group_config.synapseBridgeDownstreamUserId }}
+  SynapseIds: "3432808"
 stack_tags:
   {{ stack_group_config.default_stack_tags }}


### PR DESCRIPTION
Jinja and CFN do not play nicely here so we need to go back to explicitly specifying this parameter in the config file. 