### PR TITLE
Add missing glue-job-role dependency to S3 to JSON stack

### DIFF
--- a/config/develop/namespaced/glue-job-S3ToJsonS3.yaml
+++ b/config/develop/namespaced/glue-job-S3ToJsonS3.yaml
@@ -2,6 +2,7 @@ template_path: glue-job-S3ToJsonS3.yaml
 dependencies:
   - develop/s3-intermediate-bucket.yaml
   - develop/namespaced/invalid-sqs-queue.yaml
+  - develop/glue-job-role.yaml
 stack_name: '{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3'
 parameters:
   JobRole: !stack_output_external glue-job-role::RoleArn

--- a/config/prod/glue-job-S3ToJsonS3.yaml
+++ b/config/prod/glue-job-S3ToJsonS3.yaml
@@ -2,6 +2,7 @@ template_path: glue-job-S3ToJsonS3.yaml
 dependencies:
   - prod/s3-intermediate-bucket.yaml
   - prod/invalid-sqs-queue.yaml
+  - prod/glue-job-role.yaml
 stack_name: '{{ stack_group_config.namespace }}-glue-job-S3ToJsonS3'
 parameters:
   JobRole: !stack_output_external glue-job-role::RoleArn


### PR DESCRIPTION
One more stack fix. The Glue job role dependency was not included in the S3 to JSON stack which depends on it. This hadn't broken earlier since this stack also depends on the intermediate bucket stack, and we only just now removed the glue job role dependency from that stack.