### PR TITLE
[ETL-256] Address unit test concurrency issues

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -18,9 +18,36 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.3
 
+  upload-files:
+
+    name: Upload files to S3 bucket
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    environment: develop
+    steps:
+
+      - name: Setup code, pipenv, aws
+        uses: Sage-Bionetworks/action-pipenv-aws-setup@v1
+        with:
+          aws_access_key_id: ${{ secrets.CI_USER_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.CI_USER_SECRET_ACCESS_KEY }}
+          role_to_assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
+
+      - name: Setup sam
+        uses: aws-actions/setup-sam@v1
+        with:
+          version: 1.37.0
+
+      - name: Set namespace for non-default branch or for tag
+        if: github.ref_name != 'main'
+        run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
+
+      - name: Copy files to templates bucket
+        run: python src/scripts/manage_artifacts/artifacts.py --upload --ref $GITHUB_REF_NAME
+
   pytest-docker:
     name: Build and push testing docker image to ECR
-    needs: pre-commit
+    needs: upload-files
     runs-on: ubuntu-latest
     environment: develop
     steps:
@@ -95,33 +122,6 @@ jobs:
         run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
       - name: Run Pytest unit tests
         run: su - glue_user --command "cd $GITHUB_WORKSPACE && python3 -m pytest --namespace $NAMESPACE --artifact-bucket $CFN_BUCKET"
-
-  upload-files:
-
-    name: Upload files to S3 bucket
-    runs-on: ubuntu-latest
-    needs: unit-tests
-    environment: develop
-    steps:
-
-      - name: Setup code, pipenv, aws
-        uses: Sage-Bionetworks/action-pipenv-aws-setup@v1
-        with:
-          aws_access_key_id: ${{ secrets.CI_USER_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.CI_USER_SECRET_ACCESS_KEY }}
-          role_to_assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
-
-      - name: Setup sam
-        uses: aws-actions/setup-sam@v1
-        with:
-          version: 1.37.0
-
-      - name: Set namespace for non-default branch or for tag
-        if: github.ref_name != 'main'
-        run: echo "NAMESPACE=$GITHUB_REF_NAME" >> $GITHUB_ENV
-
-      - name: Copy files to templates bucket
-        run: python src/scripts/manage_artifacts/artifacts.py --upload --ref $GITHUB_REF_NAME
 
   sceptre-deploy-branch:
     name: Deploy branch using sceptre

--- a/tests/test_json_s3_to_parquet.py
+++ b/tests/test_json_s3_to_parquet.py
@@ -208,10 +208,10 @@ class TestJsonS3ToParquet:
         )
         iam_client.delete_role(RoleName=role_name)
 
-    @pytest.fixture(scope="class", autouse=True)
+    @pytest.fixture()
     def glue_crawler(self, glue_database, glue_database_name, glue_database_path, glue_flat_table,
                      glue_flat_table_name, glue_nested_table, glue_nested_table_name,
-                     glue_crawler_role, namespace):
+                     glue_crawler_role, json_s3_objects, namespace):
         glue_client = boto3.client("glue")
         crawler_name = "{namespace}-pytest-crawler"
         time.sleep(10) # give time for the IAM role trust policy to set in
@@ -296,16 +296,14 @@ class TestJsonS3ToParquet:
         glue_context = GlueContext(SparkSession.builder.getOrCreate())
         return glue_context
 
-    def test_upload_s3_objects(self, json_s3_objects):
+    def test_setup(self, glue_crawler):
         """
-        Since `datadir` is function scoped, we invoke the `json_s3_objects`
-        fixture once here so that it doesn't need to be invoked for all the
-        other test functions.
+        Perform setup for resources which we won't need to reference later.
         """
         pass
 
     def test_get_table(self, glue_database_name, glue_flat_table_name,
-                       glue_nested_table_name, glue_crawler, glue_context):
+                       glue_nested_table_name, glue_context):
         flat_table = json_s3_to_parquet.get_table(
                 table_name=glue_flat_table_name,
                 database_name=glue_database_name,


### PR DESCRIPTION
Addresses:

* The glue resource files – specifically schema and dataset “legacy” mappings – should be uploaded to the artifact bucket either before the unit tests run or the tests should use mocked resources. (I've moved the upload step prior to the unit test step).

* The glue crawler should use the `json_s3_objects fixture` so that we know that the test data are in S3 before we run the crawler. (I made the crawler a standard, function-scoped fixture since we just need it to run once and have no need to reference it afterwards. This allows it to use the `json_s3_objects` fixture since it is no longer class-scoped.)