### PR TITLE
[ETL-358] Remove expected validation errors in S3 to JSON S3 validation result

### DIFF
--- a/src/glue/jobs/s3_to_json_s3.py
+++ b/src/glue/jobs/s3_to_json_s3.py
@@ -359,7 +359,8 @@ def remove_expected_validation_errors(validation_result, client_info):
             relevant S3 object's metadata.
 
     Returns:
-        bool: Whether the validation errors match expected, non-severe errors.
+        dict: mapping file names (str) to their (unexpected) validation
+              errors (list[str]).
     """
     if not validation_result["errors"]:
         return validation_result["errors"]


### PR DESCRIPTION
Removes anticipated (Android) validation errors from validation error result. This makes the validation process slightly more forgiving, but the only validation errors we ignore are concerned with missing required properties, superfluous properties, and a mis-specified value in motion ("acceleration" instead of "accelerometer" or "userAcceleration") -- so there shouldn't be any issues with mis-matched parquet dataset schemas.

Tested with the [data from the E2E QA study](https://www.synapse.org/#!Synapse:syn51121831/tables/) and [our test dataset](https://www.synapse.org/#!Synapse:syn29276125/datasets/).