### PR TITLE
[ETL-453] Add module to update Glue crawlers with additional targets

### DIFF
--- a/src/scripts/add_targets_to_crawler/add_targets_to_crawler.py
+++ b/src/scripts/add_targets_to_crawler/add_targets_to_crawler.py
@@ -21,6 +21,7 @@ We then update the crawler once more to change the recrawl policy back to crawl 
 folders only.
 """
 import argparse
+import logging
 import json
 import boto3
 
@@ -73,6 +74,11 @@ def read_args():
         default="default",
         help="Which AWS profile to use."
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Set the log level to debug."
+    )
     args = parser.parse_args()
     return args
 
@@ -115,7 +121,7 @@ def add_targets_to_crawler(
         crawler_name: str,
         s3_paths: list,
         record_state=False
-    ) -> dict:
+    ):
     """
     Adds a target to a Glue crawler.
 
@@ -129,19 +135,21 @@ def add_targets_to_crawler(
             Defaults to False.
 
     Returns:
-        dict: The response from the Glue service after updating the crawler.
-
-    Raises:
-        Boto3Error: If there is an error calling the Glue service.
+        (None)
     """
+    logger = logging.getLogger(__name__)
     glue_client = aws_session.client("glue")
     # Prepare initial crawler update with recrawl behavior set to `CRAWL_EVERYTHING_POLICY`
     # so that Glue permits us to update the targets.
-    crawler_update = prepare_crawler_update(
-            aws_session=aws_session,
-            crawler_name=crawler_name,
-            record_state=record_state
-    )
+    try:
+        crawler_update = prepare_crawler_update(
+                aws_session=aws_session,
+                crawler_name=crawler_name,
+                record_state=record_state
+        )
+    except glue_client.exceptions.EntityNotFoundException:
+        logger.error("Crawler with name %s does not exist", crawler_name)
+        return
     original_recrawl_behavior = crawler_update["RecrawlPolicy"]["RecrawlBehavior"]
     crawler_update["RecrawlPolicy"] = {"RecrawlBehavior": CRAWL_EVERYTHING_POLICY}
     # Add S3 targets to the crawler update
@@ -151,35 +159,52 @@ def add_targets_to_crawler(
             "Exclusions": []
         })
     # Update the crawler with new targets
-    response = glue_client.update_crawler(**crawler_update)
+    try:
+        logger.info("Adding S3 targets to crawler %s", crawler_name)
+        response = glue_client.update_crawler(**crawler_update)
+        logger.debug(response)
+    except glue_client.exceptions.InvalidInputException as e:
+        logger.error("Something went wrong with the crawler update: %s", crawler_update)
+        logger.error(str(e))
+        return
     # If we changed the recrawl policy, change it back
     if original_recrawl_behavior != CRAWL_EVERYTHING_POLICY:
+        logger.debug("Setting crawler to use recrawl policy %s", original_recrawl_behavior)
         crawler_update = prepare_crawler_update(
                 aws_session=aws_session,
                 crawler_name=crawler_name
         )
         crawler_update["RecrawlPolicy"] = {"RecrawlBehavior": original_recrawl_behavior}
         response = glue_client.update_crawler(**crawler_update)
+        logger.debug(response)
     # Save the updated crawler details to a JSON file
-    with open(f"{crawler_name}_updated.json", "w") as f:
-        crawler_update = glue_client.get_crawler(Name=crawler_name)["Crawler"]
-        json.dump(crawler_update, f, default=str)
-    return response
+    if record_state:
+        with open(f"{crawler_name}_updated.json", "w") as f:
+            crawler_update = glue_client.get_crawler(Name=crawler_name)["Crawler"]
+            json.dump(crawler_update, f, default=str)
 
 def main():
     args = read_args()
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig()
+    logger = logging.getLogger(__name__)
     aws_session = boto3.Session(profile_name=args.aws_profile)
     if args.environment == "develop":
         bucket_name = "bridge-downstream-dev-intermediate-data"
     elif args.environment == "prod":
         bucket_name = "bridge-downstream-intermediate-data"
+    logger.debug("Using bucket %s", bucket_name)
     for study in args.studies:
+        logger.debug("Beginning update for study %s", study)
         crawler_name = CRAWLER_FORMAT.format(
                 namespace=args.namespace,
                 app=args.app,
                 study=study,
                 crawler_type=args.crawler_type
         )
+        logger.debug("Crawler name: %s", crawler_name)
         s3_paths = [
                 TARGET_FORMAT.format(
                     bucket=bucket_name,
@@ -189,6 +214,7 @@ def main():
                     dataset=dataset
                 ) for dataset in args.datasets
         ]
+        logger.debug("Targets: %s", s3_paths)
         add_targets_to_crawler(
                 aws_session=aws_session,
                 crawler_name=crawler_name,

--- a/src/scripts/add_targets_to_crawler/add_targets_to_crawler.py
+++ b/src/scripts/add_targets_to_crawler/add_targets_to_crawler.py
@@ -1,6 +1,6 @@
 """
 This module provides functions to update a Glue crawler by adding
-additional S3 targets and (potentially) modifying the recrawl policy.
+additional S3 targets.
 
 If a Glue crawler is configured to crawl new folders only, it cannot be updated
 via a regular stack update. Instead, we need to perform the following steps
@@ -11,26 +11,84 @@ to completed the update:
     2. If the crawler originally had a different recrawl policy, we can
        "undo" the change to the recrawl policy we made in the previous
        step by doing an additional update -- but only to set the recrawl policy
-       back to its original value
+       back to its original value.
 
-This script supports a specific use case which occurs when we add support for
+This script supports a use case which occurs when we add support for
 new datasets. Additional S3 targets must be added to the crawlers, but our crawlers
 recrawl policy is to only crawl new folders. So the default behavior of the function
-`add_target_to_crawler` is to add the S3 targets while overwriting the recrawl policy.
+`add_targets_to_crawler` is to add the S3 targets while overwriting the recrawl policy.
 We then update the crawler once more to change the recrawl policy back to crawl new
 folders only.
 """
+import argparse
 import json
 import boto3
 
-def prepare_crawler_update(crawler_name: str, debug=False) -> dict:
+CRAWL_EVERYTHING_POLICY = "CRAWL_EVERYTHING"
+CRAWLER_FORMAT = "{namespace}-{app}-{study}-{crawler_type}"
+TARGET_FORMAT = "s3://{bucket}/{namespace}/{app}/{study}/raw_json/dataset={dataset}/"
+
+def read_args():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "--environment",
+        required=True,
+        choices=["develop", "prod"],
+        help="The AWS environment (used to determine the S3 bucket name of each target)"
+    )
+    parser.add_argument(
+        "--crawler-type",
+        required=True,
+        choices=["standard", "array-of-records"],
+        help="The type of crawler"
+    )
+    parser.add_argument(
+        "--studies",
+        nargs="+",
+        help="List of study identifiers (e.g., cxhnxd)"
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="+",
+        help="List of dataset identifiers (e.g., ArchiveMetadata_v1)"
+    )
+    parser.add_argument(
+        "--namespace",
+        default="bridge-downstream",
+        help="The namespace."
+    )
+    parser.add_argument(
+        "--app",
+        default="mobile-toolbox",
+        help="The app name."
+    )
+    parser.add_argument(
+        "--record-state",
+        action="store_true",
+        help=("Whether to record the state of the crawler before and "
+             "after targets have been added.")
+    )
+    parser.add_argument(
+        "--aws-profile",
+        default="default",
+        help="Which AWS profile to use."
+    )
+    args = parser.parse_args()
+    return args
+
+def prepare_crawler_update(
+        aws_session: "boto3.Session",
+        crawler_name: str,
+        record_state=False
+    ) -> dict:
     """
     Get a Glue crawler and remove properties which are not allowed when
     updating the crawler.
 
     Args:
-        crawler_name (str): the name of the crawler.
-        debug (bool, optional): Whether to write the crawler and all its properties
+        aws_session (boto3.Session): A boto3 session object.
+        crawler_name (str): The name of the crawler.
+        record_state (bool, optional): Whether to write the crawler and all its properties
             (including disallowed fields) to a JSON file. This can help
             save the state of the crawler before any updates are made.
             The file will be named `{crawler_name}_original.json`. Defaults to False.
@@ -38,9 +96,9 @@ def prepare_crawler_update(crawler_name: str, debug=False) -> dict:
     Returns:
         (dict): Crawler with all disallowed properties removed
     """
-    glue_client = boto3.client('glue')
+    glue_client = aws_session.client("glue")
     crawler_update = glue_client.get_crawler(Name=crawler_name)["Crawler"]
-    if debug:
+    if record_state:
         with open(f"{crawler_name}_original.json", "w") as f:
             json.dump(crawler_update, f, default=str)
     disallowed_fields = [
@@ -52,16 +110,23 @@ def prepare_crawler_update(crawler_name: str, debug=False) -> dict:
             crawler_update.pop(key)
     return crawler_update
 
-def add_target_to_crawler(crawler_name: str, s3_paths: list, recrawl_new_only=True) -> dict:
+def add_targets_to_crawler(
+        aws_session: "boto3.Session",
+        crawler_name: str,
+        s3_paths: list,
+        record_state=False
+    ) -> dict:
     """
-    Adds a target to a Glue crawler and updates its recrawl policy
-    to recrawl new folders only.
+    Adds a target to a Glue crawler.
 
     Args:
+        aws_session (boto3.Session): A boto3 session object.
         crawler_name (str): The name of the Glue crawler to update.
         s3_paths (list): A list of S3 paths to add as targets for the crawler.
-        recrawl_new_only (bool, optional): Whether to set the recrawl policy
-            to 'CRAWL_NEW_FOLDERS_ONLY'. Defaults to True.
+        record_state (bool, optional): Whether to write the crawler and all its properties
+            to a JSON file. This can help save the state of the crawler after the targets
+            have been added. The file will be named `{crawler_name}_updated.json`.
+            Defaults to False.
 
     Returns:
         dict: The response from the Glue service after updating the crawler.
@@ -69,11 +134,16 @@ def add_target_to_crawler(crawler_name: str, s3_paths: list, recrawl_new_only=Tr
     Raises:
         Boto3Error: If there is an error calling the Glue service.
     """
-    glue_client = boto3.client('glue')
-    # Prepare initial crawler update with recrawl behavior set to 'CRAWL_EVERYTHING'
-    # so that Glue permits us to update the crawler.
-    crawler_update = prepare_crawler_update(crawler_name=crawler_name, debug=True)
-    crawler_update["RecrawlPolicy"] = {'RecrawlBehavior': 'CRAWL_EVERYTHING'}
+    glue_client = aws_session.client("glue")
+    # Prepare initial crawler update with recrawl behavior set to `CRAWL_EVERYTHING_POLICY`
+    # so that Glue permits us to update the targets.
+    crawler_update = prepare_crawler_update(
+            aws_session=aws_session,
+            crawler_name=crawler_name,
+            record_state=record_state
+    )
+    original_recrawl_behavior = crawler_update["RecrawlPolicy"]["RecrawlBehavior"]
+    crawler_update["RecrawlPolicy"] = {"RecrawlBehavior": CRAWL_EVERYTHING_POLICY}
     # Add S3 targets to the crawler update
     for path in s3_paths:
         crawler_update["Targets"]["S3Targets"].append({
@@ -82,13 +152,49 @@ def add_target_to_crawler(crawler_name: str, s3_paths: list, recrawl_new_only=Tr
         })
     # Update the crawler with new targets
     response = glue_client.update_crawler(**crawler_update)
-    # If recrawl_new_only is True, update the recrawl policy to 'CRAWL_NEW_FOLDERS_ONLY'
-    if recrawl_new_only:
-        crawler_update = prepare_crawler_update(crawler_name=crawler_name)
-        crawler_update["RecrawlPolicy"] = {'RecrawlBehavior': 'CRAWL_NEW_FOLDERS_ONLY'}
+    # If we changed the recrawl policy, change it back
+    if original_recrawl_behavior != CRAWL_EVERYTHING_POLICY:
+        crawler_update = prepare_crawler_update(
+                aws_session=aws_session,
+                crawler_name=crawler_name
+        )
+        crawler_update["RecrawlPolicy"] = {"RecrawlBehavior": original_recrawl_behavior}
         response = glue_client.update_crawler(**crawler_update)
     # Save the updated crawler details to a JSON file
     with open(f"{crawler_name}_updated.json", "w") as f:
         crawler_update = glue_client.get_crawler(Name=crawler_name)["Crawler"]
         json.dump(crawler_update, f, default=str)
     return response
+
+def main():
+    args = read_args()
+    aws_session = boto3.Session(profile_name=args.aws_profile)
+    if args.environment == "develop":
+        bucket_name = "bridge-downstream-dev-intermediate-data"
+    elif args.environment == "prod":
+        bucket_name = "bridge-downstream-intermediate-data"
+    for study in args.studies:
+        crawler_name = CRAWLER_FORMAT.format(
+                namespace=args.namespace,
+                app=args.app,
+                study=study,
+                crawler_type=args.crawler_type
+        )
+        s3_paths = [
+                TARGET_FORMAT.format(
+                    bucket=bucket_name,
+                    namespace=args.namespace,
+                    app=args.app,
+                    study=study,
+                    dataset=dataset
+                ) for dataset in args.datasets
+        ]
+        add_targets_to_crawler(
+                aws_session=aws_session,
+                crawler_name=crawler_name,
+                s3_paths=s3_paths,
+                record_state=args.record_state
+        )
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/add_targets_to_crawler/add_targets_to_crawler.py
+++ b/src/scripts/add_targets_to_crawler/add_targets_to_crawler.py
@@ -1,0 +1,94 @@
+"""
+This module provides functions to update a Glue crawler by adding
+additional S3 targets and (potentially) modifying the recrawl policy.
+
+If a Glue crawler is configured to crawl new folders only, it cannot be updated
+via a regular stack update. Instead, we need to perform the following steps
+to completed the update:
+
+    1. Perform the desired crawler updates, but ensure that the update has a
+       recrawl policy of CRAWL_EVERYTHING so that the update completes successfully.
+    2. If the crawler originally had a different recrawl policy, we can
+       "undo" the change to the recrawl policy we made in the previous
+       step by doing an additional update -- but only to set the recrawl policy
+       back to its original value
+
+This script supports a specific use case which occurs when we add support for
+new datasets. Additional S3 targets must be added to the crawlers, but our crawlers
+recrawl policy is to only crawl new folders. So the default behavior of the function
+`add_target_to_crawler` is to add the S3 targets while overwriting the recrawl policy.
+We then update the crawler once more to change the recrawl policy back to crawl new
+folders only.
+"""
+import json
+import boto3
+
+def prepare_crawler_update(crawler_name: str, debug=False) -> dict:
+    """
+    Get a Glue crawler and remove properties which are not allowed when
+    updating the crawler.
+
+    Args:
+        crawler_name (str): the name of the crawler.
+        debug (bool, optional): Whether to write the crawler and all its properties
+            (including disallowed fields) to a JSON file. This can help
+            save the state of the crawler before any updates are made.
+            The file will be named `{crawler_name}_original.json`. Defaults to False.
+
+    Returns:
+        (dict): Crawler with all disallowed properties removed
+    """
+    glue_client = boto3.client('glue')
+    crawler_update = glue_client.get_crawler(Name=crawler_name)["Crawler"]
+    if debug:
+        with open(f"{crawler_name}_original.json", "w") as f:
+            json.dump(crawler_update, f, default=str)
+    disallowed_fields = [
+            "State", "CrawlElapsedTime", "CreationTime",
+            "LastUpdated", "LastCrawl", "Version"
+    ]
+    for key in disallowed_fields:
+        if key in crawler_update:
+            crawler_update.pop(key)
+    return crawler_update
+
+def add_target_to_crawler(crawler_name: str, s3_paths: list, recrawl_new_only=True) -> dict:
+    """
+    Adds a target to a Glue crawler and updates its recrawl policy
+    to recrawl new folders only.
+
+    Args:
+        crawler_name (str): The name of the Glue crawler to update.
+        s3_paths (list): A list of S3 paths to add as targets for the crawler.
+        recrawl_new_only (bool, optional): Whether to set the recrawl policy
+            to 'CRAWL_NEW_FOLDERS_ONLY'. Defaults to True.
+
+    Returns:
+        dict: The response from the Glue service after updating the crawler.
+
+    Raises:
+        Boto3Error: If there is an error calling the Glue service.
+    """
+    glue_client = boto3.client('glue')
+    # Prepare initial crawler update with recrawl behavior set to 'CRAWL_EVERYTHING'
+    # so that Glue permits us to update the crawler.
+    crawler_update = prepare_crawler_update(crawler_name=crawler_name, debug=True)
+    crawler_update["RecrawlPolicy"] = {'RecrawlBehavior': 'CRAWL_EVERYTHING'}
+    # Add S3 targets to the crawler update
+    for path in s3_paths:
+        crawler_update["Targets"]["S3Targets"].append({
+            "Path": path,
+            "Exclusions": []
+        })
+    # Update the crawler with new targets
+    response = glue_client.update_crawler(**crawler_update)
+    # If recrawl_new_only is True, update the recrawl policy to 'CRAWL_NEW_FOLDERS_ONLY'
+    if recrawl_new_only:
+        crawler_update = prepare_crawler_update(crawler_name=crawler_name)
+        crawler_update["RecrawlPolicy"] = {'RecrawlBehavior': 'CRAWL_NEW_FOLDERS_ONLY'}
+        response = glue_client.update_crawler(**crawler_update)
+    # Save the updated crawler details to a JSON file
+    with open(f"{crawler_name}_updated.json", "w") as f:
+        crawler_update = glue_client.get_crawler(Name=crawler_name)["Crawler"]
+        json.dump(crawler_update, f, default=str)
+    return response


### PR DESCRIPTION
This module provides functions to update a glue crawler by adding additional s3 targets and (potentially) modifying the recrawl policy. If a glue crawler is configured to crawl new folders only, it cannot be updated via a regular stack update. Instead, we need to perform the following steps to completed the update:

1. Perform the desired crawler updates, but ensure that the update has a recrawl policy of crawl_everything so that the update completes successfully.
2. If the crawler originally had a different recrawl policy, we can "undo" the change to the recrawl policy we made in the previous step by doing an additional update -- but only to set the recrawl policy back to its original value

This script supports a specific use case which occurs when we add support for new datasets. Additional s3 targets must be added to the crawlers, but our crawlers recrawl policy is to only crawl new folders. So the default behavior of the function `add_target_to_crawler` is to add the s3 targets while overwriting the recrawl policy. We then update the crawler once more to change the recrawl policy back to crawl new folders only.