### PR TITLE
[ETL-458] Fixes for S3 to JSON, Glue tables

### DIFF
--- a/src/glue/resources/table_columns.yaml
+++ b/src/glue/resources/table_columns.yaml
@@ -201,9 +201,9 @@ tables:
       - Name: startDate
         Type: string
       - Name: stepHistory
-        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:integer,practice:boolean,response:integer,responseTime:double,score:integer,startDate:string,type:string,wasInterrupted:boolean>
+        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:int,practice:boolean,response:int,responseTime:double,score:int,startDate:string,type:string,wasInterrupted:boolean>
       - Name: steps
-        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:integer,practice:boolean,response:integer,responseTime:double,score:integer,startDate:string,type:string,wasInterrupted:boolean>
+        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:int,practice:boolean,response:int,responseTime:double,score:int,startDate:string,type:string,wasInterrupted:boolean>
       - Name: taskName
         Type: string
       - Name: taskRunUUID
@@ -418,9 +418,9 @@ tables:
       - Name: startDate
         Type: string
       - Name: stepHistory
-        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:integer,practice:boolean,response:integer,responseTime:double,score:integer,startDate:string,type:string,wasInterrupted:boolean>
+        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:int,practice:boolean,response:int,responseTime:double,score:int,startDate:string,type:string,wasInterrupted:boolean>
       - Name: steps
-        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:integer,practice:boolean,response:integer,responseTime:double,score:integer,startDate:string,type:string,wasInterrupted:boolean>
+        Type: struct<endDate:string,identifier:string,interactions:struct<controlEvent:string,parent:string,stepIdentifier:string,timestamp:string,userInteractionIdentifier:string,userInteractionNewStyleEncoder:boolean,value:string>,position:int,practice:boolean,response:int,responseTime:double,score:int,startDate:string,type:string,wasInterrupted:boolean>
       - Name: taskName
         Type: string
       - Name: taskRunUUID

--- a/tests/test_s3_to_json_s3.py
+++ b/tests/test_s3_to_json_s3.py
@@ -445,12 +445,8 @@ class TestS3ToJsonS3:
         )
         assert isinstance(json_schemas, list)
         file_names = [
-            "taskData",
             "taskData.json",
-            "info.json",
             "motion.json",
-            "weather.json",
-            "taskResult.json",
             "metadata.json",
         ]
         actual_file_names = [j["file_name"] for j in json_schemas]


### PR DESCRIPTION
This fixes the mistake I introduced when overwriting the json schema `$id`. I made some other fixes to make the job less dumb. Details in the comments.

I ran the new assessments and the test dataset through this pipeline and read all the parquet datasets produced from the JSON, so I'm pretty confident this works.