### PR TITLE
[ETL-444] Append a 0 (zero) in front of underscore/period records file names

### DIFF
--- a/src/glue/jobs/s3_to_json_s3.py
+++ b/src/glue/jobs/s3_to_json_s3.py
@@ -610,6 +610,9 @@ def write_file_to_json_dataset(
                 j["day"] = int(uploaded_on.day)
                 j["recordid"] = s3_obj_metadata["recordid"]
         output_fname = s3_obj_metadata["recordid"] + ".ndjson"
+        if output_fname.startswith(("_", ".")):
+            # Glue will ignore files which begin with _ or .
+            output_fname = f"0{output_fname}"
         output_path = os.path.join(dataset_identifier, output_fname)
         logger.debug(f"output_path: {output_path}")
         with open(output_path, "w") as f_out:


### PR DESCRIPTION
We've had issues with file names that begin with an underscore. The same root cause also affects file names that begin with periods, so I added that to the conditional out of an abundance of caution.