### PR TITLE
[ETL-314] Add parameter for deployment environment to manage artifacts script

### DIFF
--- a/.github/workflows/upload-and-deploy.yaml
+++ b/.github/workflows/upload-and-deploy.yaml
@@ -45,6 +45,10 @@ jobs:
       - name: Copy files to templates bucket
         run: python src/scripts/manage_artifacts/artifacts.py --upload --ref $NAMESPACE
 
+        # Hardcode --ref as stopgap for actual job script versioning
+      - name: Copy Glue scripts to templates bucket
+        run: python src/scripts/manage_artifacts/artifacts.py --upload --ref "v0.1"
+
   pytest-docker:
     name: Build and push testing docker image to ECR
     needs: upload-files
@@ -201,6 +205,13 @@ jobs:
           aws_access_key_id: ${{ secrets.CI_USER_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.CI_USER_SECRET_ACCESS_KEY }}
           role_to_assume: ${{ secrets.CI_ROLE_TO_ASSUME }}
+
+      - name: Copy files to templates bucket
+        run: python src/scripts/manage_artifacts/artifacts.py --environment $environment --upload --ref $NAMESPACE
+
+        # Hardcode --ref as stopgap for actual job script versioning
+      - name: Copy Glue scripts to templates bucket
+        run: python src/scripts/manage_artifacts/artifacts.py --environment $environment --upload --ref "v0.1"
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/src/scripts/manage_artifacts/artifacts.py
+++ b/src/scripts/manage_artifacts/artifacts.py
@@ -1,78 +1,86 @@
+"""
+Manage cloudformation artifacts for a specific ref (namespace)
+"""
 import argparse
 import subprocess
 
-cfn_bucket = 'sceptre-cloudformation-bucket-bucket-65ci2qog5w6l'
-repo_name = 'BridgeDownstream'
+REPO_NAME = 'BridgeDownstream'
 
 
 def read_args():
-  descriptions = '''
-  Uploading to S3 and deletion from S3 of scripts and templates.
-  '''
   parser = argparse.ArgumentParser(
-    description='')
-  parser.add_argument(
-    '--ref')
+    description='Uploading to S3 and deletion from S3 of scripts and templates.',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+  parser.add_argument('--ref')
   group = parser.add_mutually_exclusive_group(required=True)
   group.add_argument('--upload', action='store_true')
   group.add_argument('--remove', action='store_true')
   group.add_argument('--list', action='store_true')
+  parser.add_argument(
+          '--environment',
+          default="develop",
+          choices=["develop", "prod"],
+          help="The deployment environment")
   args = parser.parse_args()
   return args
 
 
 def execute_command(cmd):
   print(f'Invoking command: {" ".join(cmd)}')
-  subprocess.run(cmd)
+  subprocess.run(cmd, check=True)
 
 
-def upload(ref):
+def upload(ref, cfn_bucket):
   '''Copy Glue scripts to the artifacts bucket'''
   scripts_local_path = 'src/glue/'
-  scripts_s3_path = f's3://{cfn_bucket}/{repo_name}/{ref}/glue/'
+  scripts_s3_path = f's3://{cfn_bucket}/{REPO_NAME}/{ref}/glue/'
   cmd = ['aws', 's3', 'sync', scripts_local_path, scripts_s3_path]
   execute_command(cmd)
 
   '''Copies Lambda code and template to the artifacts bucket'''
   lambda_local_path = 'src/lambda/'
-  lambda_s3_path = f's3://{cfn_bucket}/{repo_name}/{ref}/lambda/'
+  lambda_s3_path = f's3://{cfn_bucket}/{REPO_NAME}/{ref}/lambda/'
   cmd = ['aws', 's3', 'sync', lambda_local_path, lambda_s3_path]
   execute_command(cmd)
 
   '''Copy EC2 resources (e.g., crontab) to the artifacts bucket'''
   resources_local_path = 'src/ec2/resources/'
-  resources_s3_path = f's3://{cfn_bucket}/{repo_name}/{ref}/ec2/resources/'
+  resources_s3_path = f's3://{cfn_bucket}/{REPO_NAME}/{ref}/ec2/resources/'
   cmd = ['aws', 's3', 'sync', resources_local_path, resources_s3_path]
   execute_command(cmd)
 
   '''Copy CFN templates to the artifacts bucket'''
   templates_local_path = 'templates/'
-  templates_s3_path = f's3://{cfn_bucket}/{repo_name}/{ref}/templates/'
+  templates_s3_path = f's3://{cfn_bucket}/{REPO_NAME}/{ref}/templates/'
   cmd = ['aws', 's3', 'sync', templates_local_path, templates_s3_path]
   execute_command(cmd)
 
-def delete(ref):
+def delete(ref, cfn_bucket):
   '''Removes all files recursively for ref'''
-  s3_path = f's3://{cfn_bucket}/{repo_name}/{ref}/'
+  s3_path = f's3://{cfn_bucket}/{REPO_NAME}/{ref}/'
   cmd = ['aws', 's3', 'rm', '--recursive', s3_path]
   execute_command(cmd)
 
 
-def list_refs():
+def list_refs(cfn_bucket):
   '''List all refs'''
-  s3_path = f's3://{cfn_bucket}/{repo_name}/'
+  s3_path = f's3://{cfn_bucket}/{REPO_NAME}/'
   cmd = ['aws','s3','ls', s3_path]
   execute_command(cmd)
 
 
-def main(args):
-  if args.upload:
-    upload(args.ref)
-  elif args.remove:
-    delete(args.ref)
+def main():
+  args = read_args()
+  if args.environment == "prod":
+    cfn_bucket = "sceptre-cloudformation-bucket-bucket-10mwvvuhlvtk9"
   else:
-    list_refs()
+    cfn_bucket = "sceptre-cloudformation-bucket-bucket-65ci2qog5w6l"
+  if args.upload:
+    upload(ref=args.ref, cfn_bucket=cfn_bucket)
+  elif args.remove:
+    delete(ref=args.ref, cfn_bucket=cfn_bucket)
+  else:
+    list_refs(cfn_bucket=cfn_bucket)
 
 if __name__ == "__main__":
-  args = read_args()
-  main(args)
+  main()


### PR DESCRIPTION
* I added a `--environment` flag for specifying the deployment environment for the `manage_artifacts` script. This makes it a lot easier to deploy to either dev or prod. I also did quite a bit of cleaning up of the `manage_artifacts` script because it was pretty rough around the edges.
* I incorporated this new parameterization into our upload-and-deploy workflow. Believe it or not, artifacts like the schema mapping and glue job scripts were not being automatically uploaded as part of our deployment until now.